### PR TITLE
Prevent labels from wrapping

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -174,6 +174,7 @@
 }
 
 .label-level1-checkbox {
+   white-space: nowrap; /* Prevents text from wrapping (even at natural breakpoints like dashes (-)) */
    color: rgb(224, 118, 52);
 }
 


### PR DESCRIPTION
Prevent labels from wrapping (even at natural breakpoints like dashes (-))