### PR TITLE
Prevent labels & checkboxes to be wrapped

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -172,10 +172,16 @@
    border-bottom: 1px solid #ccc;
    z-index: 10;
 }
+.no-wrap-inline-contents {
+   white-space: nowrap; /* Prevents line wrapping for inline child-elems (ex. checkbox and labels to go on different lines) */
+}
 
 .label-level1-checkbox {
    white-space: nowrap; /* Prevents text from wrapping (even at natural breakpoints like dashes (-)) */
    color: rgb(224, 118, 52);
+}
+.label-level2-checkbox {
+   white-space: nowrap; /* Prevents wrapping */
 }
 
 /* ------------ SINGLE TAB - MAIN COL  ------------ */

--- a/views/tabs/tab-prodowner.njk
+++ b/views/tabs/tab-prodowner.njk
@@ -81,14 +81,14 @@
       <form id="filterForm">
          {% for document in documents %}
             {% if document %}
-               <div>
+               <div class="no-wrap-inline-contents">
                   {# document._id is the scrum name and can contain invalid chars (at least spaces)
                   so those ids should be standardised before using them #}
                   {% set standardId = setStandardId(document._id) %}
 
                   <input type="checkbox" id="{{ standardId }}" class="level1-checkbox" checked>
                   <label for="{{ standardId }}" class="label-level1-checkbox">{{ document._id }}</label>
-                  <div>
+                  <div class="no-wrap-inline-contents">
                   {% for service in document.services %}
                      {% if service %}
                         <input type="checkbox" id="{{ standardId }}-{{ service.name }}" class="level2-checkbox" data-level1="{{ standardId }}" checked>

--- a/views/tabs/tab-services.njk
+++ b/views/tabs/tab-services.njk
@@ -11,10 +11,10 @@
       <form id="filterForm">
          {% for document in documents %}
             {% if document %}
-               <div>
+                  <div class="no-wrap-inline-contents">
                   <input type="checkbox" id="{{ document.name }}" class="level1-checkbox" checked>
                   <label for="{{ document.name }}" class="label-level1-checkbox">{{ document.name }}</label>
-                  <div>
+                  <div class="no-wrap-inline-contents">
                      {% for version in document.versions %}
                         {% if version %}
                            <input type="checkbox" id="{{ document.name }}-{{ version.version }}" class="level2-checkbox" data-level1="{{ document.name }}" checked>


### PR DESCRIPTION
Prevent (long)labels and their associated leading checkboxes to go on different lines