### PR TITLE
Cc 3151 dep track changes

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -19,6 +19,20 @@ a {
   text-decoration: underline;
 }
 
+span[data-tooltip] {
+  /* By default, tooltip adds a dashed border under each span - we'll override it */
+  border-bottom: 1px solid black; 
+}
+
+.tag {
+  border: 1px solid black !important;
+}
+
+.progress {
+  border: 1px solid black;
+  border-radius: 0;
+}
+
 .tag:hover {
   cursor: default;
 }

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -19,6 +19,14 @@ a {
   text-decoration: underline;
 }
 
+.tag:hover {
+  cursor: default;
+}
+
+.service-vulnerability-keys {
+  max-width: 15em;
+}
+
 .has-tooltip::before,
 .has-tooltip::after,
 .has-tooltip-bottom::before,

--- a/src/app.ts
+++ b/src/app.ts
@@ -143,6 +143,7 @@ app.get(`${config.ENDPOINT_DASHBOARD!}/teams`, async (_: Request, res: Response)
          thresholdsStaging:   thresholds.staging     || thresholds.default,
          thresholdsLive:      thresholds.live        || thresholds.default,
          depTrackUri: config.DEP_TRACK_URI,
+         depTrackFallback: "https://companieshouse.atlassian.net/wiki/x/UwACHwE", // Documentation on uploading SBOM to DepTrack
          sonarUri: config.SONAR_URI
       });
    } catch (error) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -124,7 +124,7 @@ app.get(`${config.ENDPOINT_DASHBOARD!}/details`, async (req: Request, res: Respo
    }
 });
 
-app.get(`${config.ENDPOINT_DASHBOARD!}/teams`, async (req: Request, res: Response) => {
+app.get(`${config.ENDPOINT_DASHBOARD!}/teams`, async (_: Request, res: Response) => {
    try {
       const configData = await mongo.fetchConfig();
       const endols = configData?.endol ?? {};

--- a/src/mongo/mongo.ts
+++ b/src/mongo/mongo.ts
@@ -5,6 +5,7 @@ import * as type from '../common/types';
 import {logger, logErr} from "../utils/logger";
 import {checkRuntimesVsEol, EndOfLifeData, Thresholds} from "../utils/check-eol";
 import { getDb, getSession } from "./db";
+import { servicesVersion } from "typescript";
 
 const MilliSecRetentionStateLinks = Number(config.DAYS_RETENTION_STATE_LINKS) * 24 * 60 * 60 * 1000;
 
@@ -145,9 +146,6 @@ async function fetchDocumentsGoupedByScrum(endol: EndOfLifeData, thresholds: Thr
 
       const documents = await collection.aggregate([
          {
-            $unwind: "$versions"
-         },
-         {
             $sort: { "versions.lastBomImport": -1 }
          },
          {
@@ -209,6 +207,50 @@ async function fetchDocumentsGoupedByScrum(endol: EndOfLifeData, thresholds: Thr
                service.sonarMetrics = null;
             }
 
+            service.versions = service.latestVersion;
+
+            const langArray = [service.gitInfo.lang];
+
+            for (const version of service.versions) {
+               langArray.push(version.lang);
+               if (version.runtime) {
+                  version.runtimeData = checkRuntimesVsEol(langArray, version.runtime.split(' '), endol, thresholds);
+               }
+
+               const deployments = [];
+               if (version.version == service.ecs?.cidev?.version) {
+                  deployments.push('CI-Dev');
+                  service.ecs.cidev = {
+                     ...service.ecs.cidev,
+                     ...version
+                  };
+               }
+               if (version.version == service.ecs?.staging?.version) {
+                  deployments.push('Staging');
+                  service.ecs.staging = {
+                     ...service.ecs.staging,
+                     ...version
+                  };
+               }
+               if (version.version == service.ecs?.live?.version) {
+                  deployments.push('Live');
+                  service.ecs.live = {
+                     ...service.ecs.live,
+                     ...version
+                  };
+               }
+               version.deployments = deployments;
+            }
+
+            // most recent versions first
+            service.versions = service.versions.sort((a:any, b:any) => 
+               semver.valid(a.version) && semver.valid(b.version) ? // if version is valid semver... 
+               semver.compare(a.version, b.version) : // try and sort using semver...
+               a.version.localeCompare(b.version) // else, use string comparison
+            ).reverse();
+            
+            service.latestVersion = service.versions[0];
+
             if (!service.latestVersion.runtime) {
                return {
                   ...service,
@@ -220,7 +262,7 @@ async function fetchDocumentsGoupedByScrum(endol: EndOfLifeData, thresholds: Thr
             }
 
             const runtimeStr = service.latestVersion.runtime;
-            const langArray = [service.latestVersion.lang, service.gitInfo.lang];
+            // const langArray = [service.latestVersion.lang, service.gitInfo.lang];
 
             const runtimeColorResult = checkRuntimesVsEol(langArray, runtimeStr.split(' '), endol, thresholds);
 

--- a/src/mongo/mongo.ts
+++ b/src/mongo/mongo.ts
@@ -262,7 +262,6 @@ async function fetchDocumentsGoupedByScrum(endol: EndOfLifeData, thresholds: Thr
             }
 
             const runtimeStr = service.latestVersion.runtime;
-            // const langArray = [service.latestVersion.lang, service.gitInfo.lang];
 
             const runtimeColorResult = checkRuntimesVsEol(langArray, runtimeStr.split(' '), endol, thresholds);
 

--- a/src/utils/check-eol.ts
+++ b/src/utils/check-eol.ts
@@ -118,7 +118,6 @@ export function checkRuntimesVsEol (
     } else if (hasYellow) {
         totalColor = "yellow";
     }
-    // console.log(`------------------- matchedRuntime: ${JSON.stringify({total: totalColor, runtime: runtimeColors}, null, 2)}`);
 
     return {
         total: totalColor,

--- a/test/check-eol.test.ts
+++ b/test/check-eol.test.ts
@@ -1,0 +1,144 @@
+import { checkRuntimesVsEol, EndOfLifeData, Thresholds } from "../src/utils/check-eol";
+
+describe("checkRuntimesVsEol()", () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date("2026-01-01"));
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    const thresholds: Thresholds = {
+        nodejs: [30, 90],
+        go: [60, 120],
+        "amazon-corretto": [90, 180],
+    };
+
+    const eolData: EndOfLifeData = {
+        nodejs: [
+            { cycle: "18", eol: "2026-02-15" }, // ~45 days away
+            { cycle: "16", eol: "true" }
+        ],
+        go: [
+            { cycle: "1.20", eol: "2026-12-31" }, // ~1 year away
+            { cycle: "1.19", eol: "false"}
+        ],
+        "amazon-corretto": [
+            { cycle: "21", eol: "2026-08-25" }, // eol a few months away
+            { cycle: "18", eol: "2025-01-01" }  // eol expired
+        ],
+        "spring-boot": [
+            { cycle: "4.0", eol: "2026-12-31" },
+            { cycle: "3.5", eol: "2026-06-30"},
+        ]
+    };
+
+    it("returns red when runtime array is empty", () => {
+        const result = checkRuntimesVsEol(
+            ["node"],
+            [], // empty runtime array
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "red",
+            runtime: [{ value: "Unknown", color: "red" }]
+        });
+    });
+
+    it("returns yellow if runtime is matched, within EOL but below max threshold", () => {
+        const result = checkRuntimesVsEol(
+            ["node"],
+            ["node-18"],
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "yellow",
+            runtime: [{ value: "node-18", color: "yellow" }]
+        });
+    });
+
+    it("returns green if runtime is matched, within EOL and outside of thresholds", () => {
+        const result = checkRuntimesVsEol(
+            ["go"],
+            ["1.20"],
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "green",
+            runtime: [{ value: "1.20", color: "green" }]
+        });
+    });
+
+    it("returns green if runtime is matched and EOL is 'true'", () => {
+        const result = checkRuntimesVsEol(
+            ["go"],
+            ["1.19"],
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "green",
+            runtime: [{ value: "1.19", color: "green" }]
+        });
+    });
+
+    it("sets total color to red if any runtime is red, even if others are green", () => {
+        const result = checkRuntimesVsEol(
+            ["java"],
+            ["amazon-corretto-21", "amazon-corretto-18"],
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "red",
+            runtime: [
+                { value: "amazon-corretto-21", color: "green" },
+                { value: "amazon-corretto-18", color: "red" }
+            ]
+        });
+    });
+
+    it("sets total color to yellow if any runtime is yellow", () => {
+        const result = checkRuntimesVsEol(
+            ["java"],
+            ["amazon-corretto-21", "spring-boot-starter:3.5.9"], // spring-boot has no threshold set, so will use defaults
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "yellow",
+            runtime: [
+                { value: "amazon-corretto-21", color: "green" },
+                { value: "spring-boot-starter:3.5.9", color: "yellow" }
+            ]
+        });
+    });
+
+    it("sets total color to green if all runtimes are green", () => {
+        const result = checkRuntimesVsEol(
+            ["java"],
+            ["amazon-corretto-21", "spring-boot-starter:4.0.1"], // spring-boot has no threshold set, so will use defaults
+            eolData,
+            thresholds
+        );
+
+        expect(result).toEqual({
+            total: "green",
+            runtime: [
+                { value: "amazon-corretto-21", color: "green" },
+                { value: "spring-boot-starter:4.0.1", color: "green" }
+            ]
+        });
+    });
+});

--- a/views/macros.njk
+++ b/views/macros.njk
@@ -9,7 +9,7 @@
 {% macro addDaysAgo (date) %}
    {% set value = date | daysAgo %}
       {% if value %}
-         <span class="days-ago">({{ value }})</span>
+         <span class="days-ago"> ({{ value }})</span>
       {% endif %}
 {% endmacro %}
 
@@ -124,4 +124,18 @@ The select will have:
    {% else %}
       is-danger
    {% endif %}
+{% endmacro %}
+
+
+{% macro addVulnerabilityKey(containerStyle, elementStyle) %}
+<div>
+      <p class="has-text-weight-semibold">Dependency Track Key:</p>
+      <div class="is-flex {{containerStyle}} is-justify-content-space-around">
+         <span class="{{elementStyle}} tag has-background-danger-30 has-text-white">Critical</span>
+         <span class="{{elementStyle}} tag is-danger">High</span>
+         <span class="{{elementStyle}} tag is-warning">Medium</span>
+         <span class="{{elementStyle}} tag is-success">Low</span>
+         <span class="{{elementStyle}} tag">Components</span>
+      </div>
+</div>
 {% endmacro %}

--- a/views/service.njk
+++ b/views/service.njk
@@ -1,5 +1,5 @@
 {% extends "layout.njk" %}
-{% from "macros.njk" import addCoverageColorClass %}
+{% from "macros.njk" import addCoverageColorClass, addVulnerabilityKey %}
 
 {% block content %}
     {% set dateFormat = "DD MMM YYYY - h:mm:ss A"%}
@@ -67,23 +67,25 @@
                                 <th>SonarQube Metrics</th>
                                 <td>
                                     {% if coverage == 0 %}
+                                        <p>Overall Coverage: </p>
                                         <progress class="progress" value="0" max="100" data-tooltip="Unknown Coverage">
                                             0
                                         </progress>
                                     {% else %}
+                                        <p>Overall Coverage: </p>
                                         <progress class="progress {{ addCoverageColorClass(coverage) }} has-tooltip" value="{{coverage}}" max="100" data-tooltip="{{ coverage }}% Overall Coverage">
                                             {{ coverage }}
                                         </progress>
                                     {% endif %}
                                     <div class="level">
                                         <span class="tag level-item is-danger has-tooltip" data-tooltip="Vulnerabilities">
-                                            {{ service.sonarMetrics.vulnerabilities }}
+                                            Vulnerabilities: {{ service.sonarMetrics.vulnerabilities }}
                                         </span>
                                         <span class="tag level-item is-warning has-tooltip" data-tooltip="Bugs">
-                                            {{ service.sonarMetrics.bugs }}
+                                            Bugs: {{ service.sonarMetrics.bugs }}
                                         </span>
                                         <span class="tag level-item is-info has-tooltip" data-tooltip="Code Smells">
-                                            {{ service.sonarMetrics.code_smells }}
+                                            Code Smells: {{ service.sonarMetrics.code_smells }}
                                         </span>
                                     </div>
                                 </td>
@@ -119,6 +121,9 @@
         </div>
     
         <h2 class="is-size-3">Dependency Track</h2>
+        <div class="service-vulnerability-keys">
+            {{addVulnerabilityKey("is-flex-direction-row", "ml-2")}}
+        </div>
         <table class="table is-fullwidth mt-5">
             <thead>
                 <tr>

--- a/views/teams.njk
+++ b/views/teams.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 {% set active = "teams" %}
-{% from "macros.njk" import addDaysAgo, sonarLink, depTrackLink, DepTrackMetrics, setStandardId, addCoverageColorClass %}
+{% from "macros.njk" import addDaysAgo, sonarLink, depTrackLink, DepTrackMetrics, setStandardId, addCoverageColorClass, addVulnerabilityKey %}
 
 {% macro gitReleaseInfo(versionData, min, max) %}
     {% set ReleaseDate = versionData.gitReleaseDate%}
@@ -13,12 +13,12 @@
 
     <li title="{{ ReleaseDate }}">
         {% if versionData.uuid %}
-            <a href="{{depTrackUri}}/projects/{{versionData.uuid}}/findings">
+            <a class="has-text-black" href="{{depTrackUri}}/projects/{{versionData.uuid}}/findings">
                 {{ versionData.version }}
             </a>
             {{addDaysAgo( ReleaseDate ) }}
         {% else %}
-            <a href="{{depTrackFallback}}">
+            <a class="has-text-black" href="{{depTrackFallback}}">
                 {{ versionData.version }}
             </a>
             {{addDaysAgo( ReleaseDate ) }}
@@ -124,6 +124,8 @@
                 {% endif %}
             {% endfor %}
             </form>
+            <hr>
+            {{addVulnerabilityKey("is-flex-direction-column", "mt-2")}}
         </div>
 
         <div class="column table-container">

--- a/views/teams.njk
+++ b/views/teams.njk
@@ -168,15 +168,15 @@
                         <td class="td-runtime">
                             {% for info in service.latestVersion.runtime.runtime %}
                                 {% if info %}
-                                {% if info.color == "red" %}
-                                    <span class="tag is-danger">{{ info.value }}</span>
-                                {% elseif info.color == "green" %}
-                                    <span class="tag is-success">{{ info.value }}</span>
-                                {% elseif info.color == "yellow" %}
-                                    <span class="tag is-warning">{{ info.value }}</span>
-                                {% elseif info.color == "none" %}
-                                    <span class="tag is-info">{{ info.value }}</span>
-                                {% endif %}
+                                    {% if info.color == "red" %}
+                                        <span class="tag is-danger">{{ info.value }}</span>
+                                    {% elseif info.color == "green" %}
+                                        <span class="tag is-success">{{ info.value }}</span>
+                                    {% elseif info.color == "yellow" %}
+                                        <span class="tag is-warning">{{ info.value }}</span>
+                                    {% elseif info.color == "none" %}
+                                        <span class="tag is-info">{{ info.value }}</span>
+                                    {% endif %}
                                 {% endif %}
                             {% endfor %}
                         </td>

--- a/views/teams.njk
+++ b/views/teams.njk
@@ -2,16 +2,28 @@
 {% set active = "teams" %}
 {% from "macros.njk" import addDaysAgo, sonarLink, depTrackLink, DepTrackMetrics, setStandardId, addCoverageColorClass %}
 
-{% macro gitReleaseInfo(version, ReleaseDate, min, max, repoLink) %}
-   {% if ReleaseDate %}
-      {% set ReleaseDate = ReleaseDate | date("YYYY-MM-DD") %}
-   {% else %}
-      {% set ReleaseDate = "no date loaded" %}
-   {% endif %}
+{% macro gitReleaseInfo(versionData, min, max) %}
+    {% set ReleaseDate = versionData.gitReleaseDate%}
+    
+    {% if ReleaseDate %}
+        {% set ReleaseDate = ReleaseDate | date("YYYY-MM-DD") %}
+    {% else %}
+        {% set ReleaseDate = "no date loaded" %}
+    {% endif %}
 
-   <li title="{{ ReleaseDate }}">
-      <p>{{ version }}</p>{{addDaysAgo( ReleaseDate ) }}
-   </li>
+    <li title="{{ ReleaseDate }}">
+        {% if versionData.uuid %}
+            <a href="{{depTrackUri}}/projects/{{versionData.uuid}}/findings">
+                {{ versionData.version }}
+            </a>
+            {{addDaysAgo( ReleaseDate ) }}
+        {% else %}
+            <a href="{{depTrackFallback}}">
+                {{ versionData.version }}
+            </a>
+            {{addDaysAgo( ReleaseDate ) }}
+        {% endif %}
+    </li>
 {% endmacro %}
 
 {% macro addSonarColorClass(bugs, coverage) %}
@@ -46,11 +58,9 @@
         <td class="td-ecs {{ addDepTrackColorClass(metrics.critical, metrics.high, metrics.medium) }}">
             <ul class="td-git-version-info">
                 {{ gitReleaseInfo(
-                    versionData.version,
-                    versionData.gitReleaseDate,
+                    versionData,
                     thresholdsLive[0],
-                    thresholdsLive[1],
-                    service.gitInfo.repo
+                    thresholdsLive[1]
                 ) }}
                 {% if versionData.metrics %}
                     <div class="level">

--- a/views/teams.njk
+++ b/views/teams.njk
@@ -30,12 +30,53 @@
 
 {% macro addDepTrackColorClass(critical, high, medium) %}
    {% if critical != 0 %}
+      has-background-danger
+   {% elseif high != 0 %}
       has-background-danger-light
-   {% elseif high != 0 or medium != 0 %}
+   {% elseif medium != 0 %}
       has-background-warning-light
    {% else %}
       has-background-success-light
    {% endif %}
+{% endmacro %}
+
+{% macro buildServiceVersionCell(versionData) %}
+    {% if versionData.version %}
+        {% set metrics = versionData.metrics %}
+        <td class="td-ecs {{ addDepTrackColorClass(metrics.critical, metrics.high, metrics.medium) }}">
+            <ul class="td-git-version-info">
+                {{ gitReleaseInfo(
+                    versionData.version,
+                    versionData.gitReleaseDate,
+                    thresholdsLive[0],
+                    thresholdsLive[1],
+                    service.gitInfo.repo
+                ) }}
+                {% if versionData.metrics %}
+                    <div class="level">
+                        <span class="tag level-item tag has-background-danger-30 has-text-white has-tooltip has-tooltip-bottom" data-tooltip="Critical">
+                            {{ versionData.metrics.critical }}
+                        </span>
+                        <span class="tag level-item is-danger has-tooltip-bottom" data-tooltip="High">
+                            {{ versionData.metrics.high }}
+                        </span>
+                        <span class="tag level-item is-warning has-tooltip-bottom" data-tooltip="Medium">
+                            {{ versionData.metrics.medium }}
+                        </span>
+                        <span class="tag level-item is-success has-tooltip-bottom" data-tooltip="Low">
+                            {{ versionData.metrics.low }}
+                        </span>
+                    </div>
+                {% else %}
+                    <span class="tag level-item is-warning has-tooltip-bottom" data-tooltip="SBOM for this version is missing from Dependency Track">
+                        SBOM Missing
+                    </span>
+                {% endif %}
+            </ul>
+        </td>
+    {% else %}
+        <td />
+    {% endif %}
 {% endmacro %}
 
 {% block content %}
@@ -85,7 +126,6 @@
                 <th class="row-header-title header-ecs" id="col-head-ecs-stag">Staging</th>
                 <th class="row-header-title header-ecs" id="col-head-ecs-live">Live</th>
                 <th class="row-header-title header-sonar-metric" id="col-head-sonar-coverage">Sonar</th>
-                <th class="row-header-title header-deptrack" id="col-head-deptrack">Dependencies</th>
                 </tr>
             </thead>
 
@@ -130,49 +170,13 @@
                         </td>
 
                         <!-- CI DEV -->
-                        <td class="td-ecs">
-                            <ul class="td-git-version-info">
-                            {% if service.ecs.cidev.version %}
-                                {{ gitReleaseInfo(
-                                service.ecs.cidev.version,
-                                service.ecs.cidev.gitReleaseDate,
-                                thresholdsCidev[0],
-                                thresholdsCidev[1],
-                                service.gitInfo.repo
-                                ) }}
-                            {% endif %}
-                            </ul>
-                        </td>
+                        {{ buildServiceVersionCell(service.ecs.cidev) }}
 
                         <!-- STAGING -->
-                        <td class="td-ecs">
-                            <ul class="td-git-version-info">
-                            {% if service.ecs.staging.version %}
-                                {{ gitReleaseInfo(
-                                service.ecs.staging.version,
-                                service.ecs.staging.gitReleaseDate,
-                                thresholdsStaging[0],
-                                thresholdsStaging[1],
-                                service.gitInfo.repo
-                                ) }}
-                            {% endif %}
-                            </ul>
-                        </td>
+                        {{ buildServiceVersionCell(service.ecs.staging) }}
 
                         <!-- LIVE -->
-                        <td class="td-ecs">
-                            <ul class="td-git-version-info">
-                            {% if service.ecs.live.version %}
-                                {{ gitReleaseInfo(
-                                service.ecs.live.version,
-                                service.ecs.live.gitReleaseDate,
-                                thresholdsLive[0],
-                                thresholdsLive[1],
-                                service.gitInfo.repo
-                                ) }}
-                            {% endif %}
-                            </ul>
-                        </td>
+                        {{ buildServiceVersionCell(service.ecs.live) }}
 
                         <!-- SONAR -->
                         {% set sonarBugs = service.sonarMetrics.bugs %}
@@ -201,28 +205,7 @@
                                 </div>
                             {% endif%}
                         </td>
-
-                        <!-- DEP TRACK -->
-                        {% set uuid             = service.latestVersion.uuid %}
-                        <td class="td-deptrack-metrics {{ addDepTrackColorClass(depTrackCritical, depTrackHigh, depTrackMedium) }}">
-                            {% if service.latestVersion.metrics %}
-                                <div class="level">
-                                    <span class="tag level-item tag has-background-danger-30 has-text-white has-tooltip has-tooltip-bottom" data-tooltip="Critical">
-                                        {{ depTrackCritical }}
-                                    </span>
-                                    <span class="tag level-item is-danger has-tooltip-bottom" data-tooltip="High">
-                                        {{ depTrackHigh }}
-                                    </span>
-                                    <span class="tag level-item is-warning has-tooltip-bottom" data-tooltip="Medium">
-                                        {{ depTrackMedium }}
-                                    </span>
-                                    <span class="tag level-item is-success has-tooltip-bottom" data-tooltip="Low">
-                                        {{ depTrackLow }}
-                                    </span>
-                                </div>
-                            {% endif %}
-                        </td>
-                        </tr>
+                    </tr>
                     {% endif %}
                     {% endfor %}
                 {% endif %}


### PR DESCRIPTION
- Refactor "teams" page to include dep track stats for each version
- Fix some styling issues on tags/progress bars
- Add tests for end-of-life calculations
- Provide a fallback url if no dep track link available
- Refactor mongo request

NOTE: The mongo changes are sizeable and still need a good deal of refactoring. But this is a big enough PR without those changes 