### PR TITLE
Display non-standard environment versions if available

### DIFF
--- a/src/mongo/mongo.ts
+++ b/src/mongo/mongo.ts
@@ -83,6 +83,20 @@ export function processDeployments(document: ServiceDocument) {
             ...version
          };
       }
+      if (version.version == document.ecs?.rebel1?.version) {
+         deployments.push('Rebel1');
+         document.ecs.rebel1 = {
+            ...document.ecs.rebel1,
+            ...version
+         };
+      }
+      if (version.version == document.ecs?.phoenix?.version) {
+         deployments.push('Phoenix');
+         document.ecs.phoenix = {
+            ...document.ecs.phoenix,
+            ...version
+         };
+      }
       if (version.version == document.ecs?.staging?.version) {
          deployments.push('Staging');
          document.ecs.staging = {

--- a/test/mongo.test.ts
+++ b/test/mongo.test.ts
@@ -40,6 +40,8 @@ describe("fetchDocument()", () => {
       sonarMetrics: null,
       ecs: {
         cidev:   { version: "2.0.0" },
+        rebel1:   { version: "2.0.0" },
+        phoenix:   { version: "2.0.0" },
         staging: { version: "0.1.100" },
         live:    { version: "0.1.99" }
       },
@@ -62,7 +64,7 @@ describe("fetchDocument()", () => {
     expect(result!.versions[0].runtimeData).toBe("MOCK_RUNTIME_DATA");
 
     // --- deployments based on ecs versions ---
-    expect(result!.versions[0].deployments).toEqual(["CI-Dev"]);
+    expect(result!.versions[0].deployments).toEqual(["CI-Dev", "Rebel1", "Phoenix"]);
     expect(result!.versions[1].deployments).toEqual(["Staging"]);
     expect(result!.versions[2].deployments).toEqual(["Live"]);
 

--- a/views/service.njk
+++ b/views/service.njk
@@ -25,6 +25,17 @@
     </div>
 {% endmacro %}
 
+{% macro buildVersionAndDate(version, releaseDate) %}
+    {% if version | isEmpty %}
+        Unknown
+    {% else %}
+        <strong>{{version}} </strong>
+        {% if releaseDate %}
+            - {{releaseDate | date(dateFormat)}}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
 {% block content %}
     {% set dateFormat = "DD MMM YYYY - h:mm:ss A"%}
     {% if service %}
@@ -52,39 +63,7 @@
                                 {% endif %}
                             </td>
                         </tr>
-                        <tr>
-                            <th>CI-Dev</th>
-                            <td>
-                                {% if ecs.cidev.version %}
-                                    <strong>{{ecs.cidev.version}} </strong>
-                                    - {{ecs.cidev.gitReleaseDate | date(dateFormat)}}
-                                {% else %}
-                                    Unknown
-                                {% endif %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>Staging</th>
-                            <td>
-                                {% if ecs.staging.version %}
-                                    <strong>{{ecs.staging.version}} </strong>
-                                    - {{ecs.staging.gitReleaseDate | date(dateFormat)}}
-                                {% else %}
-                                    Unknown
-                                {% endif %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>Live</th>
-                            <td>
-                                {% if ecs.live.version %}
-                                    <strong>{{ecs.live.version}} </strong>
-                                    - {{ecs.live.gitReleaseDate | date(dateFormat)}}
-                                {% else %}
-                                    Unknown
-                                {% endif %}
-                            </td>
-                        </tr>
+                        
                         {% if service.sonarMetrics %}
                             <tr>
                                 <th>SonarQube Metrics</th>
@@ -126,6 +105,54 @@
                                 </td>
                             </tr>
                         {% endfor %}
+                    </tbody>
+                </table>
+
+                <table class="table is-bordered is-fullwidth">
+                    <tbody>
+                        <tr>
+                            <th>CI-Dev</th>
+                            <td>
+                                {% if ecs.cidev.version %}
+                                    {{ buildVersionAndDate(ecs.cidev.version, ecs.cidev.gitReleaseDate) }}
+                                {% else %}
+                                    Unknown
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {# Double check non-standard envs, if they are missing, don't display them #}
+                        {% if ecs.rebel1.version %}
+                        <tr>
+                            <th>Rebel1</th>
+                            <td>
+                                {{ buildVersionAndDate(ecs.rebel1.version, ecs.rebel1.gitReleaseDate) }}
+                            </td>
+                        </tr>
+                        {% endif %}
+                        {% if ecs.phoenix.version %}
+                        <tr>
+                            <th>Phoenix</th>
+                            <td>
+                                {{ buildVersionAndDate(ecs.phoenix.version, ecs.phoenix.gitReleaseDate) }}
+                            </td>
+                        </tr>
+                        {% endif %}
+                        <tr>
+                            <th>Staging</th>
+                            <td>
+                                {% if ecs.staging.version %}
+                                    {{ buildVersionAndDate(ecs.staging.version, ecs.staging.gitReleaseDate) }}
+                                {% else %}
+                                    Unknown
+                                {% endif %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Live</th>
+                            <td>
+                                {{ buildVersionAndDate(ecs.live.version, ecs.live.gitReleaseDate) }}
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
# Describe the changes
* Display non-standard environments (Rebel1, Phoenix) on the service page

## Related Jira tickets
NONE

## Developer check list
* [x] Any UI changes tested in both light and dark mode?
* [x] Are FAQs on the /help page up-to-date?
* [x] Are accessibility scores impacted by these changes?